### PR TITLE
V1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+ignore.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ print(d, type(d))
 ```python
 from datetime import date
 
-accepted_object_inputs = str | date | int | float
+accepted_object_inputs = str | int | float | dt.datetime | dt.date
 accepted_string_inputs = {
-    str: ["str", "string", "text"],
-    date: ["date", "datetime", "datetime.date", "dt", "dt.date"],
-    int: ["int", "timestamp", "epoch", "unix", "float"],
+    "str": ["str", "string", "text", ],
+    "int": ["int", "timestamp", "epoch", "unix", "float", ],
+    "date": ["datetime.datetime", "datetime", "date", "dt", "dt.datetime", "dt.date", ],
 }
 ```
 

--- a/date_to.py
+++ b/date_to.py
@@ -6,10 +6,10 @@ import datetime as dt
 from dateparser import parse
 
 
-DateTypes = str | int | float | dt.date
+DateTypes = str | int | float | dt.datetime | dt.date
 ACCEPTED_STRINGS = {
     "str": ["str", "string", "text", ],
-    "date": ["datetime.date", "datetime", "date", "dt", "dt.date", ],
+    "date": ["datetime.datetime", "datetime", "date", "dt", "dt.datetime", "dt.date", ],
     "int": ["int", "timestamp", "epoch", "unix", "float", ],
 }
 
@@ -21,7 +21,7 @@ DEFAULT_SETTINGS = {
 }
 
 
-def date_to(your_date: DateTypes, /, end_type: DateTypes = dt.date,  
+def date_to(your_date: DateTypes, /, end_type: DateTypes = dt.datetime,  
             timezone: str = None, *, parser_settings: dict = None,
             ) -> DateTypes:
     """
@@ -39,7 +39,7 @@ def date_to(your_date: DateTypes, /, end_type: DateTypes = dt.date,
     if isinstance(your_date, (int, float)):
         your_date = _round_timestamp_to_seconds(your_date)
 
-    if end_type == dt.date:
+    if end_type == dt.datetime:
         if isinstance(your_date, str):
             return _str_to_datetime(your_date, settings)
         return _to_datetime(your_date, settings)
@@ -47,7 +47,7 @@ def date_to(your_date: DateTypes, /, end_type: DateTypes = dt.date,
     elif end_type == int or end_type == float:
         if isinstance(your_date, str):
             return _string_date_to_timestamp(your_date, settings)
-        elif isinstance(your_date, dt.date):
+        elif isinstance(your_date, dt.datetime):
             return _date_time_to_timestamp(your_date)
 
     elif end_type == str:
@@ -62,7 +62,7 @@ def date_to(your_date: DateTypes, /, end_type: DateTypes = dt.date,
 
 # =====================================
 
-def _str_to_datetime(_str_date: str, settings: dict) -> dt.date:
+def _str_to_datetime(_str_date: str, settings: dict) -> dt.datetime:
     _datetime = parse(_str_date, settings=settings)
     if not _datetime:
         raise DateInputError(f"Input string could not be parsed! Input: {_str_date}")
@@ -70,7 +70,7 @@ def _str_to_datetime(_str_date: str, settings: dict) -> dt.date:
         return _datetime
 
 
-def _to_datetime(_time: DateTypes, settings: dict) -> dt.date:
+def _to_datetime(_time: DateTypes, settings: dict) -> dt.datetime:
     if not isinstance(_time, (int, float)):
         _time = _date_time_to_timestamp(_time)
 
@@ -118,6 +118,8 @@ def _validate_end_type(end_type):
     
     if end_type == float:
         end_type = int
+    elif end_type == dt.date:
+        end_type = dt.datetime
     
     if isinstance(end_type, str):
         if end_type.lower() in ACCEPTED_STRINGS["str"]:
@@ -132,7 +134,7 @@ def _validate_end_type(end_type):
                 f"Accepted string representations are: {ACCEPTED_STRINGS}"
             )
             
-    elif end_type != str and end_type != int and end_type != dt.date:
+    elif end_type != str and end_type != int and end_type != dt.datetime:
         raise TypeError(f"Invalid input {end_type=} given. \n"
                         f"The only date input types allowed are {DateTypes} either as an object or in string representation.")
 

--- a/date_to.py
+++ b/date_to.py
@@ -1,5 +1,5 @@
 """A handy python function to parse and convert to and between datetime.datetime, int, and string objects"""
-__version__ = "1.1"
+__version__ = "1.2"
 
 import math
 import datetime as dt

--- a/date_to.py
+++ b/date_to.py
@@ -33,11 +33,10 @@ def date_to(your_date: DateTypes, /, end_type: DateTypes = dt.datetime,
     """
     
     end_type = _validate_end_type(end_type)
-
     settings = _parse_settings(timezone, parser_settings)
-    
     if isinstance(your_date, (int, float)):
         your_date = _round_timestamp_to_seconds(your_date)
+
 
     if end_type == dt.datetime:
         if isinstance(your_date, str):
@@ -95,6 +94,7 @@ def _parse_settings(timezone: str = None, parser_settings: dict = None) -> dict:
         settings = parser_settings if parser_settings else DEFAULT_SETTINGS
         if timezone:
             settings["TO_TIMEZONE"] = timezone.upper()
+            settings["tz"] = timezone
         return settings
 
 

--- a/date_to.py
+++ b/date_to.py
@@ -125,7 +125,7 @@ def _validate_end_type(end_type):
         if end_type.lower() in ACCEPTED_STRINGS["str"]:
             end_type = str
         elif end_type.lower() in ACCEPTED_STRINGS["date"]:
-            end_type = dt.date
+            end_type = dt.datetime
         elif end_type.lower() in ACCEPTED_STRINGS["int"]:
             end_type = int
         else:
@@ -139,3 +139,11 @@ def _validate_end_type(end_type):
                         f"The only date input types allowed are {DateTypes} either as an object or in string representation.")
 
     return end_type
+
+if __name__ == "__main__":
+    TIME_INT = 1000243252
+    TIME_DATE = dt.datetime(2001, 9, 11, 21, 20, 52, tzinfo=dt.timezone.utc)
+    print(f"{TIME_DATE = }")
+    converted_date = date_to(TIME_INT, "dt")
+    print(f"{converted_date = }")
+    

--- a/test_date_to.py
+++ b/test_date_to.py
@@ -30,6 +30,15 @@ def test_basic_input_output(input_date, input_type, expected):
     assert date_to(input_date, input_type) == expected
 
 
+@pytest.mark.parametrize("input_date, input_type, tz, expected", [
+    (LOCAL_STR, str, "JST", "2001-09-12T06:20:52+09:00"),
+    (TIME_STR, str, "JST", "2001-09-12T06:20:52+09:00"),
+    # (LOCAL_STR, "datetime", "JST", "2001-09-12T06:20:52+09:00"),
+])
+def test_timezone_conversion(input_date, input_type, tz, expected):
+    assert date_to(input_date, input_type, tz) == expected
+
+
 def test_invalid_str_endtype():
     with pytest.raises(KeyError):
         date_to(LOCAL_STR, "Not a valid datetype")

--- a/test_date_to.py
+++ b/test_date_to.py
@@ -1,19 +1,18 @@
 import pytest
-import datetime
+import datetime as dt
 from date_to import date_to, DateInputError
 
 
 LOCAL_STR = "2001-09-11 17:20:52 EDT"
 TIME_STR = "2001-09-11T21:20:52+00:00"
 TIME_INT = 1000243252
-TIME_DATE = datetime.datetime(2001, 9, 11, 21, 20, 52, tzinfo=datetime.timezone.utc)
+TIME_DATE = dt.datetime(2001, 9, 11, 21, 20, 52, tzinfo=dt.timezone.utc)
 
 
 @pytest.mark.parametrize("input_date, input_type, expected", [
     (LOCAL_STR, str, TIME_STR),
     (LOCAL_STR, int, TIME_INT),
-    (LOCAL_STR, float, TIME_INT),
-    (LOCAL_STR, datetime.datetime, TIME_DATE),
+    (LOCAL_STR, dt.datetime, TIME_DATE),
     
     (TIME_INT, "str", TIME_STR),
     (TIME_INT, "int", TIME_INT),
@@ -23,8 +22,10 @@ TIME_DATE = datetime.datetime(2001, 9, 11, 21, 20, 52, tzinfo=datetime.timezone.
     (TIME_DATE, "timestamp", TIME_INT),
     (TIME_DATE, "date", TIME_DATE),
     
+    (LOCAL_STR, float, TIME_INT),
     (TIME_INT+0.2, "unix", TIME_INT),
     (TIME_INT*10**3, "epoch", TIME_INT),
+    (TIME_INT, dt.date, TIME_DATE)
 ])
 def test_basic_input_output(input_date, input_type, expected):
     assert date_to(input_date, input_type) == expected
@@ -33,7 +34,6 @@ def test_basic_input_output(input_date, input_type, expected):
 @pytest.mark.parametrize("input_date, input_type, tz, expected", [
     (LOCAL_STR, str, "JST", "2001-09-12T06:20:52+09:00"),
     (TIME_STR, str, "JST", "2001-09-12T06:20:52+09:00"),
-    # (LOCAL_STR, "datetime", "JST", "2001-09-12T06:20:52+09:00"),
 ])
 def test_timezone_conversion(input_date, input_type, tz, expected):
     assert date_to(input_date, input_type, tz) == expected

--- a/test_date_to.py
+++ b/test_date_to.py
@@ -13,7 +13,7 @@ TIME_DATE = datetime.datetime(2001, 9, 11, 21, 20, 52, tzinfo=datetime.timezone.
     (LOCAL_STR, str, TIME_STR),
     (LOCAL_STR, int, TIME_INT),
     (LOCAL_STR, float, TIME_INT),
-    (LOCAL_STR, datetime.date, TIME_DATE),
+    (LOCAL_STR, datetime.datetime, TIME_DATE),
     
     (TIME_INT, "str", TIME_STR),
     (TIME_INT, "int", TIME_INT),

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ passenv = HOME
 deps = pipenv
 commands = 
     pipenv install --dev
-    pipenv run pytest --cov-report term-missing:skip-covered --cov=date_to
+    pipenv run pytest --cov-report term-missing --cov=date_to


### PR DESCRIPTION
- **Fixed**: ```datetime.datetime``` object support
- **Added**:  Timezone conversion with the optional ```timezone=``` keyword argument. Default conversion is to UTC